### PR TITLE
Add Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+npm-debug.log
+test_data.json
+__tests__
+server/node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+# Build stage
+FROM node:20 AS build
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm install
+COPY . .
+RUN npx next build
+
+# Production stage
+FROM node:20-alpine AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+COPY --from=build /app .
+EXPOSE 3000
+CMD ["npx", "next", "start"]

--- a/README.md
+++ b/README.md
@@ -31,6 +31,18 @@ The API listens on port `3001` by default and exposes the following endpoints:
 
 This backend uses a simple JSON file for persistence. Replace it with a proper database for production.
 
+## Running with Docker Compose
+
+You can run both the frontend and backend using Docker. Build and start the
+containers using:
+
+```bash
+docker compose up --build
+```
+
+The frontend will be available on [http://localhost:3000](http://localhost:3000)
+and the API on [http://localhost:3001](http://localhost:3001).
+
 ## Development
 
 Run tests and format code using:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3.8'
+services:
+  frontend:
+    build: .
+    ports:
+      - "3000:3000"
+    depends_on:
+      - backend
+  backend:
+    build: ./server
+    ports:
+      - "3001:3001"
+    environment:
+      - PORT=3001

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm install --production
+COPY . .
+EXPOSE 3001
+CMD ["npm", "start"]


### PR DESCRIPTION
## Summary
- add Dockerfile for Next.js frontend
- add Dockerfile for Express backend
- add docker-compose config to run both containers
- document how to use Docker Compose in README

## Testing
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_6869f577b6e0832a866f038862c7ca3d