### PR TITLE
Use blank head emoji when avatar missing

### DIFF
--- a/app/auth/signup/page.tsx
+++ b/app/auth/signup/page.tsx
@@ -135,14 +135,20 @@ export default function SignUpPage() {
                       <div className="w-24 h-24 rounded-full overflow-hidden bg-gradient-to-r from-amber-200 to-orange-200 flex items-center justify-center">
                         {formData.avatar ? (
                           <Image
-                            src={formData.avatar || '/placeholder.svg'}
+                            src={formData.avatar}
                             alt="Avatar"
                             width={96}
                             height={96}
                             className="w-full h-full object-cover"
                           />
                         ) : (
-                          <User className="w-10 h-10 text-amber-600" />
+                          <span
+                            className="text-5xl"
+                            role="img"
+                            aria-label="No avatar"
+                          >
+                            👤
+                          </span>
                         )}
                       </div>
                       <button

--- a/app/explore/page.tsx
+++ b/app/explore/page.tsx
@@ -287,13 +287,23 @@ export default function ExplorePage() {
               >
                 <div className="flex items-center justify-between">
                   <div className="flex items-center gap-4">
-                    <Image
-                      src={user.avatar || '/placeholder.svg'}
-                      alt={user.name}
-                      width={50}
-                      height={50}
-                      className="w-12 h-12 rounded-full object-cover border-2 border-amber-200"
-                    />
+                    {user.avatar ? (
+                      <Image
+                        src={user.avatar}
+                        alt={user.name}
+                        width={50}
+                        height={50}
+                        className="w-12 h-12 rounded-full object-cover border-2 border-amber-200"
+                      />
+                    ) : (
+                      <span
+                        className="w-12 h-12 flex items-center justify-center text-3xl border-2 border-amber-200 rounded-full"
+                        role="img"
+                        aria-label="No avatar"
+                      >
+                        👤
+                      </span>
+                    )}
                     <div>
                       <h3 className="font-semibold text-amber-900">
                         {user.name}

--- a/app/profile/settings/page.tsx
+++ b/app/profile/settings/page.tsx
@@ -172,13 +172,23 @@ export default function SettingsPage() {
               {/* Avatar */}
               <div className="text-center mb-6">
                 <div className="relative inline-block">
-                  <Image
-                    src={user.avatar || "/placeholder.svg?height=100&width=100"}
-                    alt={user.name}
-                    width={100}
-                    height={100}
-                    className="w-24 h-24 rounded-full object-cover border-4 border-amber-200"
-                  />
+                  {user.avatar ? (
+                    <Image
+                      src={user.avatar}
+                      alt={user.name}
+                      width={100}
+                      height={100}
+                      className="w-24 h-24 rounded-full object-cover border-4 border-amber-200"
+                    />
+                  ) : (
+                    <span
+                      className="w-24 h-24 flex items-center justify-center text-6xl border-4 border-amber-200 rounded-full"
+                      role="img"
+                      aria-label="No avatar"
+                    >
+                      👤
+                    </span>
+                  )}
                   <button
                     onClick={() => document.getElementById("avatar-upload")?.click()}
                     className="absolute -bottom-2 -right-2 bg-amber-500 text-white p-2 rounded-full shadow-lg hover:bg-amber-600 transition-colors"

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -183,13 +183,23 @@ export default function Navbar() {
                       {/* Special handling for profile with avatar */}
                       {item.showAvatar && user ? (
                         <div className="relative mb-1">
-                          <Image
-                            src={user.avatar || "/placeholder.svg?height=24&width=24"}
-                            alt={user.name}
-                            width={24}
-                            height={24}
-                            className="w-6 h-6 rounded-full object-cover border-2 border-current"
-                          />
+                          {user.avatar ? (
+                            <Image
+                              src={user.avatar}
+                              alt={user.name}
+                              width={24}
+                              height={24}
+                              className="w-6 h-6 rounded-full object-cover border-2 border-current"
+                            />
+                          ) : (
+                            <span
+                              className="w-6 h-6 flex items-center justify-center text-xl"
+                              role="img"
+                              aria-label="No avatar"
+                            >
+                              👤
+                            </span>
+                          )}
                           {item.isActive && (
                             <div className="absolute -top-1 -right-1 w-3 h-3 bg-amber-500 rounded-full border-2 border-white"></div>
                           )}


### PR DESCRIPTION
## Summary
- show blank head emoji when no avatar in navigation
- show blank head emoji during signup
- show blank head emoji in profile settings
- show blank head emoji in explore user list

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686b9723233c832a84241cd2f69405cd