### PR TITLE
Swap Home and Explore placement in navbar

### DIFF
--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -145,7 +145,7 @@ export default function Navbar() {
         <div className="max-w-md mx-auto">
           <div className="bg-white/80 backdrop-blur-xl border border-white/20 rounded-3xl shadow-2xl p-2">
             <div
-              className="grid place-items-center"
+              className="grid"
               style={{ gridTemplateColumns: `repeat(${navItems.length}, minmax(0, 1fr))` }}
             >
               {navItems.map((item) => {

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -153,7 +153,7 @@ export default function Navbar() {
                     <button
                       key={item.id}
                       onClick={item.onClick}
-                      className={`relative flex flex-col items-center justify-center p-3 rounded-2xl transition-all duration-300 min-w-0 flex-1 ${
+                      className={`relative flex flex-col items-center justify-center p-3 rounded-2xl transition-all duration-300 w-full flex-1 ${
                         item.isSpecial
                           ? "bg-gradient-to-r from-amber-500 to-orange-500 text-white shadow-lg hover:shadow-xl hover:scale-105"
                           : item.isActive
@@ -170,9 +170,9 @@ export default function Navbar() {
                 }
 
                 return (
-                  <Link key={item.id} href={item.href || "/"}>
+                  <Link key={item.id} href={item.href || "/"} className="flex-1">
                     <button
-                      className={`relative flex flex-col items-center justify-center p-3 rounded-2xl transition-all duration-300 min-w-0 flex-1 ${
+                      className={`relative flex flex-col items-center justify-center p-3 rounded-2xl transition-all duration-300 w-full ${
                         item.isSpecial
                           ? "bg-gradient-to-r from-amber-500 to-orange-500 text-white shadow-lg hover:shadow-xl hover:scale-105"
                           : item.isActive

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -145,7 +145,7 @@ export default function Navbar() {
         <div className="max-w-md mx-auto">
           <div className="bg-white/80 backdrop-blur-xl border border-white/20 rounded-3xl shadow-2xl p-2">
             <div
-              className="grid"
+              className="grid place-items-center"
               style={{ gridTemplateColumns: `repeat(${navItems.length}, minmax(0, 1fr))` }}
             >
               {navItems.map((item) => {
@@ -156,7 +156,7 @@ export default function Navbar() {
                     <button
                       key={item.id}
                       onClick={item.onClick}
-                      className={`relative flex flex-col items-center justify-center p-3 rounded-2xl transition-all duration-300 w-full flex-1 ${
+                      className={`relative flex flex-col items-center justify-center p-3 rounded-2xl transition-all duration-300 w-full h-full flex-1 ${
                         item.isSpecial
                           ? "bg-gradient-to-r from-amber-500 to-orange-500 text-white shadow-lg hover:shadow-xl hover:scale-105"
                           : item.isActive
@@ -173,9 +173,9 @@ export default function Navbar() {
                 }
 
                 return (
-                  <Link key={item.id} href={item.href || "/"} className="flex-1">
+                  <Link key={item.id} href={item.href || "/"} className="flex-1 h-full">
                     <button
-                      className={`relative flex flex-col items-center justify-center p-3 rounded-2xl transition-all duration-300 w-full ${
+                      className={`relative flex flex-col items-center justify-center p-3 rounded-2xl transition-all duration-300 w-full h-full ${
                         item.isSpecial
                           ? "bg-gradient-to-r from-amber-500 to-orange-500 text-white shadow-lg hover:shadow-xl hover:scale-105"
                           : item.isActive

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useRef } from "react"
 import { usePathname, useRouter } from "next/navigation"
 import Link from "next/link"
 import Image from "next/image"
-import { Home, Plus, Search, User, Coffee, Bell, LogIn, UserPlus, Compass, type LucideIcon } from "lucide-react"
+import { Star, Plus, Search, User, Coffee, Bell, LogIn, UserPlus, Compass, type LucideIcon } from "lucide-react"
 
 interface NavbarUser {
   id: string
@@ -74,11 +74,11 @@ export default function Navbar() {
           isActive: pathname === "/explore",
         },
         {
-          id: "dashboard",
-          label: "Dashboard",
-          icon: Coffee,
-          href: "/dashboard",
-          isActive: pathname === "/dashboard",
+          id: "ratings",
+          label: "Ratings",
+          icon: Star,
+          href: "/",
+          isActive: pathname === "/",
         },
         {
           id: "new",
@@ -89,15 +89,15 @@ export default function Navbar() {
           isSpecial: true, // This will be the main CTA button
         },
         {
-          id: "home",
-          label: "Home",
-          icon: Home,
-          href: "/",
-          isActive: pathname === "/",
+          id: "dashboard",
+          label: "Dashboard",
+          icon: Coffee,
+          href: "/dashboard",
+          isActive: pathname === "/dashboard",
         },
         {
-          id: "profile",
-          label: "Profile",
+          id: "settings",
+          label: "Settings",
           icon: User,
           href: "/profile/settings",
           isActive: pathname.startsWith("/profile"),
@@ -113,9 +113,9 @@ export default function Navbar() {
           isActive: pathname === "/explore",
         },
         {
-          id: "home",
-          label: "Home",
-          icon: Home,
+          id: "ratings",
+          label: "Ratings",
+          icon: Star,
           href: "/",
           isActive: pathname === "/",
         },
@@ -144,7 +144,10 @@ export default function Navbar() {
       >
         <div className="max-w-md mx-auto">
           <div className="bg-white/80 backdrop-blur-xl border border-white/20 rounded-3xl shadow-2xl p-2">
-            <div className="flex items-center justify-between">
+            <div
+              className="grid"
+              style={{ gridTemplateColumns: `repeat(${navItems.length}, minmax(0, 1fr))` }}
+            >
               {navItems.map((item) => {
                 const Icon = item.icon
 

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -67,11 +67,11 @@ export default function Navbar() {
   const navItems: NavItem[] = user
     ? [
         {
-          id: "home",
-          label: "Home",
-          icon: Home,
-          href: "/",
-          isActive: pathname === "/",
+          id: "explore",
+          label: "Explore",
+          icon: Compass,
+          href: "/explore",
+          isActive: pathname === "/explore",
         },
         {
           id: "dashboard",
@@ -89,11 +89,11 @@ export default function Navbar() {
           isSpecial: true, // This will be the main CTA button
         },
         {
-          id: "explore",
-          label: "Explore",
-          icon: Compass,
-          href: "/explore",
-          isActive: pathname === "/explore",
+          id: "home",
+          label: "Home",
+          icon: Home,
+          href: "/",
+          isActive: pathname === "/",
         },
         {
           id: "profile",
@@ -106,18 +106,18 @@ export default function Navbar() {
       ]
     : [
         {
-          id: "home",
-          label: "Home",
-          icon: Home,
-          href: "/",
-          isActive: pathname === "/",
-        },
-        {
           id: "explore",
           label: "Explore",
           icon: Search,
           href: "/explore",
           isActive: pathname === "/explore",
+        },
+        {
+          id: "home",
+          label: "Home",
+          icon: Home,
+          href: "/",
+          isActive: pathname === "/",
         },
         {
           id: "login",


### PR DESCRIPTION
## Summary
- show `Explore` first on the navbar
- move `Home` after the rating button

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686c112baefc832abd92665f7a38ecc6