### PR TITLE
Change default avatar emoji

### DIFF
--- a/app/auth/signup/page.tsx
+++ b/app/auth/signup/page.tsx
@@ -147,7 +147,7 @@ export default function SignUpPage() {
                             role="img"
                             aria-label="No avatar"
                           >
-                            👤
+                            🙂
                           </span>
                         )}
                       </div>

--- a/app/explore/page.tsx
+++ b/app/explore/page.tsx
@@ -301,7 +301,7 @@ export default function ExplorePage() {
                         role="img"
                         aria-label="No avatar"
                       >
-                        👤
+                        🙂
                       </span>
                     )}
                     <div>

--- a/app/profile/settings/page.tsx
+++ b/app/profile/settings/page.tsx
@@ -186,7 +186,7 @@ export default function SettingsPage() {
                       role="img"
                       aria-label="No avatar"
                     >
-                      👤
+                      🙂
                     </span>
                   )}
                   <button

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -200,7 +200,7 @@ export default function Navbar() {
                               role="img"
                               aria-label="No avatar"
                             >
-                              👤
+                              🙂
                             </span>
                           )}
                           {item.isActive && (


### PR DESCRIPTION
## Summary
- use a coloured head emoji as the default avatar across the app

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686c2326ff28832a93ac834d58cb55fd