### PR TITLE
Add clustered map to Explore page

### DIFF
--- a/app/explore/page.tsx
+++ b/app/explore/page.tsx
@@ -11,8 +11,7 @@ import {
   Heart,
   CircleUserRound,
 } from 'lucide-react'
-import { MapContainer, TileLayer, Marker, Popup } from 'react-leaflet'
-import MarkerClusterGroup from 'react-leaflet-cluster'
+import dynamic from 'next/dynamic'
 
 interface User {
   id: string
@@ -78,6 +77,10 @@ export default function ExplorePage() {
   const [topUsers, setTopUsers] = useState<User[]>([])
   const [currentUser, setCurrentUser] = useState<any>(null)
   const [localRatings, setLocalRatings] = useState<LocalRating[]>([])
+  const ExploreMap = useMemo(
+    () => dynamic(() => import('../../components/explore-map'), { ssr: false }),
+    [],
+  )
 
   useEffect(() => {
     const user = localStorage.getItem('currentUser')
@@ -346,52 +349,7 @@ export default function ExplorePage() {
           </div>
         )}
 
-        {activeTab === 'map' && (
-          <div className="h-96 rounded-2xl overflow-hidden bg-white/80 backdrop-blur-sm shadow-lg">
-            <MapContainer
-              center={
-                locationGroups.length > 0
-                  ? [
-                      locationGroups[0].location.lat,
-                      locationGroups[0].location.lng,
-                    ]
-                  : [0, 0]
-              }
-              zoom={13}
-              style={{ height: '100%', width: '100%' }}
-            >
-              <TileLayer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" />
-              <MarkerClusterGroup chunkedLoading>
-                {locationGroups.map((group, idx) => (
-                  <Marker
-                    key={idx}
-                    position={[group.location.lat, group.location.lng]}
-                  >
-                    <Popup>
-                      <div className="space-y-1">
-                        <div className="font-semibold text-amber-900">
-                          {group.location.name}
-                        </div>
-                        <div className="flex items-center gap-1 text-amber-700">
-                          <Star className="w-4 h-4 text-amber-500 fill-current" />
-                          <span className="font-medium">
-                            {group.average.toFixed(1)}
-                          </span>
-                        </div>
-                        <a
-                          href={`/view/${group.firstId}`}
-                          className="text-amber-600 underline text-sm"
-                        >
-                          View Ratings
-                        </a>
-                      </div>
-                    </Popup>
-                  </Marker>
-                ))}
-              </MarkerClusterGroup>
-            </MapContainer>
-          </div>
-        )}
+        {activeTab === 'map' && <ExploreMap groups={locationGroups} />}
       </div>
     </div>
   )

--- a/app/explore/page.tsx
+++ b/app/explore/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useMemo } from 'react'
 import Image from 'next/image'
 import {
   Search,
@@ -11,6 +11,8 @@ import {
   Heart,
   CircleUserRound,
 } from 'lucide-react'
+import { MapContainer, TileLayer, Marker, Popup } from 'react-leaflet'
+import MarkerClusterGroup from 'react-leaflet-cluster'
 
 interface User {
   id: string
@@ -46,6 +48,27 @@ interface CommunityRating {
   isLiked?: boolean
 }
 
+interface LocalRating {
+  id: string
+  photo: string
+  location: {
+    lat: number
+    lng: number
+    name: string
+  }
+  ratings: {
+    temperature: number
+    sweetness: number
+    texture: number
+    chocolate: number
+    creaminess: number
+    presentation: number
+  }
+  notes: string
+  timestamp: string
+  userId?: string
+}
+
 export default function ExplorePage() {
   const [activeTab, setActiveTab] = useState('nearby')
   const [searchQuery, setSearchQuery] = useState('')
@@ -54,6 +77,7 @@ export default function ExplorePage() {
   )
   const [topUsers, setTopUsers] = useState<User[]>([])
   const [currentUser, setCurrentUser] = useState<any>(null)
+  const [localRatings, setLocalRatings] = useState<LocalRating[]>([])
 
   useEffect(() => {
     const user = localStorage.getItem('currentUser')
@@ -64,6 +88,24 @@ export default function ExplorePage() {
     // In a real app this would fetch community data from the API
     setCommunityRatings([])
     setTopUsers([])
+
+    // Load ratings saved locally
+    try {
+      const raw = localStorage.getItem('hotChocRatings')
+      if (raw) {
+        const parsed = JSON.parse(raw)
+        if (Array.isArray(parsed)) {
+          setLocalRatings(
+            parsed.filter(
+              (r: LocalRating) =>
+                r.location && r.location.lat && r.location.lng,
+            ),
+          )
+        }
+      }
+    } catch (err) {
+      console.error('Failed to read local ratings', err)
+    }
   }, [])
 
   const getAverageRating = (ratings: CommunityRating['ratings']) => {
@@ -106,6 +148,32 @@ export default function ExplorePage() {
       ),
     )
   }
+
+  const ratingAverage = (r: LocalRating['ratings']) => {
+    const vals = Object.values(r)
+    return vals.reduce((s, v) => s + v, 0) / vals.length
+  }
+
+  const locationGroups = useMemo(() => {
+    const map = new Map<
+      string,
+      { location: LocalRating['location']; ratings: LocalRating[] }
+    >()
+    localRatings.forEach((r) => {
+      const key = `${r.location.lat},${r.location.lng}`
+      if (!map.has(key)) {
+        map.set(key, { location: r.location, ratings: [] })
+      }
+      map.get(key)!.ratings.push(r)
+    })
+    return Array.from(map.values()).map((g) => ({
+      ...g,
+      average:
+        g.ratings.reduce((sum, r) => sum + ratingAverage(r.ratings), 0) /
+        g.ratings.length,
+      firstId: g.ratings[0].id,
+    }))
+  }, [localRatings])
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-amber-50 via-orange-50 to-rose-50">
@@ -279,57 +347,49 @@ export default function ExplorePage() {
         )}
 
         {activeTab === 'map' && (
-          <div className="space-y-4">
-            {topUsers.map((user) => (
-              <div
-                key={user.id}
-                className="bg-white/80 backdrop-blur-sm rounded-2xl shadow-lg p-6"
-              >
-                <div className="flex items-center justify-between">
-                  <div className="flex items-center gap-4">
-                    {user.avatar ? (
-                      <Image
-                        src={user.avatar}
-                        alt={user.name}
-                        width={50}
-                        height={50}
-                        className="w-12 h-12 rounded-full object-cover border-2 border-amber-200"
-                      />
-                    ) : (
-                      <span
-                        className="w-12 h-12 flex items-center justify-center border-2 border-amber-200 rounded-full"
-                        role="img"
-                        aria-label="No avatar"
-                      >
-                        <CircleUserRound className="w-6 h-6 text-amber-500" />
-                      </span>
-                    )}
-                    <div>
-                      <h3 className="font-semibold text-amber-900">
-                        {user.name}
-                      </h3>
-                      <div className="flex items-center gap-4 text-sm text-amber-600">
-                        <span>{user.stats.totalRatings} ratings</span>
-                        <div className="flex items-center gap-1">
-                          <Star className="w-3 h-3 text-amber-500 fill-current" />
-                          <span>{user.stats.averageRating}</span>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <button
-                    onClick={() => handleFollow(user.id)}
-                    className={`px-6 py-2 rounded-full font-medium transition-all duration-300 ${
-                      user.isFollowing
-                        ? 'bg-gray-200 text-gray-700 hover:bg-gray-300'
-                        : 'bg-gradient-to-r from-amber-500 to-orange-500 text-white hover:from-amber-600 hover:to-orange-600 shadow-lg hover:shadow-xl'
-                    }`}
+          <div className="h-96 rounded-2xl overflow-hidden bg-white/80 backdrop-blur-sm shadow-lg">
+            <MapContainer
+              center={
+                locationGroups.length > 0
+                  ? [
+                      locationGroups[0].location.lat,
+                      locationGroups[0].location.lng,
+                    ]
+                  : [0, 0]
+              }
+              zoom={13}
+              style={{ height: '100%', width: '100%' }}
+            >
+              <TileLayer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" />
+              <MarkerClusterGroup chunkedLoading>
+                {locationGroups.map((group, idx) => (
+                  <Marker
+                    key={idx}
+                    position={[group.location.lat, group.location.lng]}
                   >
-                    {user.isFollowing ? 'Following' : 'Follow'}
-                  </button>
-                </div>
-              </div>
-            ))}
+                    <Popup>
+                      <div className="space-y-1">
+                        <div className="font-semibold text-amber-900">
+                          {group.location.name}
+                        </div>
+                        <div className="flex items-center gap-1 text-amber-700">
+                          <Star className="w-4 h-4 text-amber-500 fill-current" />
+                          <span className="font-medium">
+                            {group.average.toFixed(1)}
+                          </span>
+                        </div>
+                        <a
+                          href={`/view/${group.firstId}`}
+                          className="text-amber-600 underline text-sm"
+                        >
+                          View Ratings
+                        </a>
+                      </div>
+                    </Popup>
+                  </Marker>
+                ))}
+              </MarkerClusterGroup>
+            </MapContainer>
           </div>
         )}
       </div>

--- a/app/explore/page.tsx
+++ b/app/explore/page.tsx
@@ -7,7 +7,7 @@ import {
   Filter,
   Star,
   MapPin,
-  Map,
+  Map as MapIcon,
   Heart,
   CircleUserRound,
 } from 'lucide-react'
@@ -238,7 +238,7 @@ export default function ExplorePage() {
                   : 'text-amber-700 hover:bg-amber-50'
               }`}
             >
-              <Map className="w-4 h-4" />
+              <MapIcon className="w-4 h-4" />
               <span className="font-medium">Map</span>
             </button>
           </div>

--- a/components/explore-map.tsx
+++ b/components/explore-map.tsx
@@ -1,0 +1,59 @@
+'use client'
+
+import { MapContainer, TileLayer, Marker, Popup } from 'react-leaflet'
+import MarkerClusterGroup from 'react-leaflet-cluster'
+import 'leaflet/dist/leaflet.css'
+import { Star } from 'lucide-react'
+
+export interface LocationGroup {
+  location: { lat: number; lng: number; name: string }
+  ratings: any[]
+  average: number
+  firstId: string
+}
+
+export default function ExploreMap({ groups }: { groups: LocationGroup[] }) {
+  return (
+    <div className="h-96 rounded-2xl overflow-hidden bg-white/80 backdrop-blur-sm shadow-lg">
+      <MapContainer
+        center={
+          groups.length > 0
+            ? [groups[0].location.lat, groups[0].location.lng]
+            : [0, 0]
+        }
+        zoom={13}
+        style={{ height: '100%', width: '100%' }}
+      >
+        <TileLayer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" />
+        <MarkerClusterGroup chunkedLoading>
+          {groups.map((group, idx) => (
+            <Marker
+              key={idx}
+              position={[group.location.lat, group.location.lng]}
+            >
+              <Popup>
+                <div className="space-y-1">
+                  <div className="font-semibold text-amber-900">
+                    {group.location.name}
+                  </div>
+                  <div className="flex items-center gap-1 text-amber-700">
+                    <Star className="w-4 h-4 text-amber-500 fill-current" />
+                    <span className="font-medium">
+                      {group.average.toFixed(1)}
+                    </span>
+                  </div>
+                  <a
+                    href={`/view/${group.firstId}`}
+                    className="text-amber-600 underline text-sm"
+                  >
+                    View Ratings
+                  </a>
+                </div>
+              </Popup>
+            </Marker>
+          ))}
+        </MarkerClusterGroup>
+      </MapContainer>
+    </div>
+  )
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,8 @@
         "next": "^14.2.3",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-leaflet": "^4.2.1"
+        "react-leaflet": "^4.2.1",
+        "react-leaflet-cluster": "^2.1.0"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.1.0",
@@ -8843,6 +8844,15 @@
       "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
       "license": "BSD-2-Clause"
     },
+    "node_modules/leaflet.markercluster": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/leaflet.markercluster/-/leaflet.markercluster-1.5.3.tgz",
+      "integrity": "sha512-vPTw/Bndq7eQHjLBVlWpnGeLa3t+3zGiuM7fJwCkiMFq+nmRuG3RI3f7f4N4TDX7T4NpbAXpR2+NTRSEGfCSeA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "leaflet": "^1.3.1"
+      }
+    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -10313,6 +10323,21 @@
         "leaflet": "^1.9.0",
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/react-leaflet-cluster": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/react-leaflet-cluster/-/react-leaflet-cluster-2.1.0.tgz",
+      "integrity": "sha512-16X7XQpRThQFC4PH4OpXHimGg19ouWmjxjtpxOeBKpvERSvIRqTx7fvhTwkEPNMFTQ8zTfddz6fRTUmUEQul7g==",
+      "license": "SEE LICENSE IN <LICENSE>",
+      "dependencies": {
+        "leaflet.markercluster": "^1.5.3"
+      },
+      "peerDependencies": {
+        "leaflet": "^1.8.0",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0",
+        "react-leaflet": "^4.0.0"
       }
     },
     "node_modules/read-cache": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "next": "^14.2.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-leaflet": "^4.2.1"
+    "react-leaflet": "^4.2.1",
+    "react-leaflet-cluster": "^2.1.0"
   }
 }


### PR DESCRIPTION
## Summary
- add `react-leaflet-cluster` dependency
- load local ratings and group them by location
- display an interactive Leaflet map with clustered markers on the Explore page

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686c53a74534832a9153d140ab5d0894