### PR TITLE
Add explore map clustering

### DIFF
--- a/__tests__/MapWithClusters.test.tsx
+++ b/__tests__/MapWithClusters.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
+
+jest.mock('react-leaflet', () => ({
+  MapContainer: ({ children }: any) => <div data-testid="map">{children}</div>,
+  TileLayer: () => null,
+  Marker: ({ children }: any) => <div data-testid="marker">{children}</div>,
+  Popup: ({ children }: any) => <div>{children}</div>,
+}))
+
+jest.mock('react-leaflet-cluster', () =>
+  ({ children }: any) => <div data-testid="cluster">{children}</div>,
+)
+
+jest.mock('next/link', () => {
+  return ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  )
+})
+
+import MapWithClusters from '../components/MapWithClusters'
+
+describe('MapWithClusters', () => {
+  test('renders markers from localStorage', () => {
+    const rating = {
+      id: '1',
+      location: { lat: 1, lng: 2, name: 'Cafe' },
+      ratings: { a: 4, b: 2, c: 3, d: 5, e: 4, f: 2 },
+    }
+    localStorage.setItem('hotChocRatings', JSON.stringify([rating]))
+    render(<MapWithClusters />)
+    expect(screen.getByTestId('map')).toBeInTheDocument()
+    expect(screen.getAllByTestId('marker').length).toBe(1)
+  })
+})

--- a/app/explore/page.tsx
+++ b/app/explore/page.tsx
@@ -66,7 +66,6 @@ export default function ExplorePage() {
 
     // In a real app this would fetch community data from the API
     setCommunityRatings([])
-    setTopUsers([])
   }, [])
 
   const getAverageRating = (ratings: CommunityRating['ratings']) => {

--- a/app/explore/page.tsx
+++ b/app/explore/page.tsx
@@ -9,8 +9,12 @@ import {
   MapPin,
   Map,
   Heart,
-  CircleUserRound,
 } from 'lucide-react'
+import dynamic from 'next/dynamic'
+
+const MapWithClusters = dynamic(() => import('@/components/MapWithClusters'), {
+  ssr: false,
+})
 
 interface User {
   id: string
@@ -52,7 +56,6 @@ export default function ExplorePage() {
   const [communityRatings, setCommunityRatings] = useState<CommunityRating[]>(
     [],
   )
-  const [topUsers, setTopUsers] = useState<User[]>([])
   const [currentUser, setCurrentUser] = useState<any>(null)
 
   useEffect(() => {
@@ -99,13 +102,6 @@ export default function ExplorePage() {
     )
   }
 
-  const handleFollow = (userId: string) => {
-    setTopUsers((prev) =>
-      prev.map((user) =>
-        user.id === userId ? { ...user, isFollowing: !user.isFollowing } : user,
-      ),
-    )
-  }
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-amber-50 via-orange-50 to-rose-50">
@@ -278,60 +274,7 @@ export default function ExplorePage() {
           </div>
         )}
 
-        {activeTab === 'map' && (
-          <div className="space-y-4">
-            {topUsers.map((user) => (
-              <div
-                key={user.id}
-                className="bg-white/80 backdrop-blur-sm rounded-2xl shadow-lg p-6"
-              >
-                <div className="flex items-center justify-between">
-                  <div className="flex items-center gap-4">
-                    {user.avatar ? (
-                      <Image
-                        src={user.avatar}
-                        alt={user.name}
-                        width={50}
-                        height={50}
-                        className="w-12 h-12 rounded-full object-cover border-2 border-amber-200"
-                      />
-                    ) : (
-                      <span
-                        className="w-12 h-12 flex items-center justify-center border-2 border-amber-200 rounded-full"
-                        role="img"
-                        aria-label="No avatar"
-                      >
-                        <CircleUserRound className="w-6 h-6 text-amber-500" />
-                      </span>
-                    )}
-                    <div>
-                      <h3 className="font-semibold text-amber-900">
-                        {user.name}
-                      </h3>
-                      <div className="flex items-center gap-4 text-sm text-amber-600">
-                        <span>{user.stats.totalRatings} ratings</span>
-                        <div className="flex items-center gap-1">
-                          <Star className="w-3 h-3 text-amber-500 fill-current" />
-                          <span>{user.stats.averageRating}</span>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <button
-                    onClick={() => handleFollow(user.id)}
-                    className={`px-6 py-2 rounded-full font-medium transition-all duration-300 ${
-                      user.isFollowing
-                        ? 'bg-gray-200 text-gray-700 hover:bg-gray-300'
-                        : 'bg-gradient-to-r from-amber-500 to-orange-500 text-white hover:from-amber-600 hover:to-orange-600 shadow-lg hover:shadow-xl'
-                    }`}
-                  >
-                    {user.isFollowing ? 'Following' : 'Follow'}
-                  </button>
-                </div>
-              </div>
-            ))}
-          </div>
-        )}
+        {activeTab === 'map' && <MapWithClusters />}
       </div>
     </div>
   )

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,8 @@ import type React from "react"
 import type { Metadata } from "next"
 import "./globals.css"
 import 'leaflet/dist/leaflet.css'
+import 'leaflet.markercluster/dist/MarkerCluster.css'
+import 'leaflet.markercluster/dist/MarkerCluster.Default.css'
 import Navbar from "@/components/navbar"
 
 export const metadata: Metadata = {

--- a/components/MapWithClusters.tsx
+++ b/components/MapWithClusters.tsx
@@ -1,0 +1,70 @@
+"use client"
+
+import { useState, useEffect } from "react"
+import { MapContainer, TileLayer, Marker, Popup } from "react-leaflet"
+import MarkerClusterGroup from "react-leaflet-cluster"
+import Link from "next/link"
+
+interface Rating {
+  id: string
+  location: { lat: number; lng: number; name: string }
+  ratings: { [key: string]: number }
+}
+
+export default function MapWithClusters() {
+  const [ratings, setRatings] = useState<Rating[]>([])
+
+  useEffect(() => {
+    let stored: any[] = []
+    try {
+      const raw = localStorage.getItem("hotChocRatings")
+      if (raw) {
+        const parsed = JSON.parse(raw)
+        if (Array.isArray(parsed)) stored = parsed
+      }
+    } catch (err) {
+      console.error("Failed to load ratings", err)
+    }
+    setRatings(stored)
+  }, [])
+
+  const getAverageRating = (obj: Rating["ratings"]) => {
+    const vals = Object.values(obj)
+    return (vals.reduce((s, v) => s + v, 0) / vals.length).toFixed(1)
+  }
+
+  const center: [number, number] = ratings.length
+    ? [ratings[0].location.lat, ratings[0].location.lng]
+    : [51.505, -0.09]
+
+  return (
+    <div className="h-96 w-full">
+      <MapContainer
+        center={center}
+        zoom={13}
+        scrollWheelZoom
+        style={{ height: "100%", width: "100%" }}
+      >
+        <TileLayer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" />
+        <MarkerClusterGroup chunkedLoading>
+          {ratings.map((r) => (
+            <Marker
+              key={r.id}
+              position={[r.location.lat, r.location.lng]}
+            >
+              <Popup>
+                <div className="text-center">
+                  <p className="font-semibold">{r.location.name}</p>
+                  <p className="mb-2 text-sm">{getAverageRating(r.ratings)} ★</p>
+                  <Link href={`/view/${r.id}`} className="text-amber-700 underline">
+                    View all ratings
+                  </Link>
+                </div>
+              </Popup>
+            </Marker>
+          ))}
+        </MarkerClusterGroup>
+      </MapContainer>
+    </div>
+  )
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,8 @@
         "next": "^14.2.3",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-leaflet": "^4.2.1"
+        "react-leaflet": "^4.2.1",
+        "react-leaflet-cluster": "^2.1.0"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.1.0",
@@ -8843,6 +8844,15 @@
       "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
       "license": "BSD-2-Clause"
     },
+    "node_modules/leaflet.markercluster": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/leaflet.markercluster/-/leaflet.markercluster-1.5.3.tgz",
+      "integrity": "sha512-vPTw/Bndq7eQHjLBVlWpnGeLa3t+3zGiuM7fJwCkiMFq+nmRuG3RI3f7f4N4TDX7T4NpbAXpR2+NTRSEGfCSeA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "leaflet": "^1.3.1"
+      }
+    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -10313,6 +10323,21 @@
         "leaflet": "^1.9.0",
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/react-leaflet-cluster": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/react-leaflet-cluster/-/react-leaflet-cluster-2.1.0.tgz",
+      "integrity": "sha512-16X7XQpRThQFC4PH4OpXHimGg19ouWmjxjtpxOeBKpvERSvIRqTx7fvhTwkEPNMFTQ8zTfddz6fRTUmUEQul7g==",
+      "license": "SEE LICENSE IN <LICENSE>",
+      "dependencies": {
+        "leaflet.markercluster": "^1.5.3"
+      },
+      "peerDependencies": {
+        "leaflet": "^1.8.0",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0",
+        "react-leaflet": "^4.0.0"
       }
     },
     "node_modules/read-cache": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "next": "^14.2.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-leaflet": "^4.2.1"
+    "react-leaflet": "^4.2.1",
+    "react-leaflet-cluster": "^2.1.0"
   }
 }


### PR DESCRIPTION
## Summary
- add `react-leaflet-cluster` dependency
- include MarkerCluster CSS globally
- implement `MapWithClusters` component
- show map with clusters on Explore page
- add test for map component

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686c54082868832aa094f8c594de81f9