### PR TITLE
Enable shared SQLite storage for ratings

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This project contains a Next.js frontend for rating hot chocolate drinks. The original app stored all data in `localStorage`.
 
-A simple Express backend has been added under `server/` to provide a real API for user management and ratings. Data is persisted in a JSON file for demonstration purposes.
+A simple Express backend has been added under `server/` to provide a real API for user management and ratings. Data is persisted in a SQLite database for demonstration purposes.
 
 ## Running the frontend
 
@@ -29,7 +29,7 @@ The API listens on port `3001` by default and exposes the following endpoints:
 - `POST /api/ratings` – create a rating (requires `Authorization: Bearer <token>`)
 - `GET /api/ratings/:id` – fetch a single rating
 
-This backend uses a simple JSON file for persistence. Replace it with a proper database for production.
+This backend uses a small SQLite database for persistence so ratings are available from any device.
 
 ## Running with Docker Compose
 
@@ -59,4 +59,3 @@ npm install
 npm test
 npm run format
 ```
-

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 This project contains a Next.js frontend for rating hot chocolate drinks. The original app stored all data in `localStorage`.
 
 A simple Express backend has been added under `server/` to provide a real API for user management and ratings. Data is persisted in a SQLite database so user accounts and ratings are shared across devices.
+Large photo uploads are supported by configuring the Express JSON body parser to accept payloads up to 10 MB.
 
 ## Running the frontend
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This project contains a Next.js frontend for rating hot chocolate drinks. The original app stored all data in `localStorage`.
 
-A simple Express backend has been added under `server/` to provide a real API for user management and ratings. Data is persisted in a SQLite database for demonstration purposes.
+A simple Express backend has been added under `server/` to provide a real API for user management and ratings. Data is persisted in a SQLite database so user accounts and ratings are shared across devices.
 
 ## Running the frontend
 
@@ -29,7 +29,7 @@ The API listens on port `3001` by default and exposes the following endpoints:
 - `POST /api/ratings` – create a rating (requires `Authorization: Bearer <token>`)
 - `GET /api/ratings/:id` – fetch a single rating
 
-This backend uses a small SQLite database for persistence so ratings are available from any device.
+This backend uses a small SQLite database for persistence so ratings and users are available from any device.
 
 ## Running with Docker Compose
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ The API listens on port `3001` by default and exposes the following endpoints:
 - `GET /api/ratings` – list all ratings
 - `POST /api/ratings` – create a rating (requires `Authorization: Bearer <token>`)
 - `GET /api/ratings/:id` – fetch a single rating
+- `GET /api/user/ratings` – list ratings created by the authenticated user
 
 This backend uses a small SQLite database for persistence so ratings and users are available from any device.
 

--- a/__tests__/server.test.js
+++ b/__tests__/server.test.js
@@ -92,4 +92,25 @@ describe('server api', () => {
     expect(Array.isArray(list2.body)).toBe(true)
     expect(list2.body.length).toBe(0)
   })
+
+  test('handles large rating payloads', async () => {
+    const user = { name: 'Big', email: 'big@example.com', password: 'pass' }
+    await request(app).post('/api/register').send(user)
+    const login = await request(app)
+      .post('/api/login')
+      .send({ email: user.email, password: user.password })
+    const token = login.body.token
+    const bigPhoto = 'x'.repeat(200000) // ~200kb string
+    const res = await request(app)
+      .post('/api/ratings')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        photo: bigPhoto,
+        location: { name: 'Cafe' },
+        ratings: {},
+        notes: '',
+      })
+    expect(res.status).toBe(200)
+    expect(res.body.photo.length).toBe(bigPhoto.length)
+  })
 })

--- a/__tests__/server.test.js
+++ b/__tests__/server.test.js
@@ -60,4 +60,36 @@ describe('server api', () => {
     const list = await request(app).get('/api/ratings')
     expect(list.body.find((r) => r.id === ratingId)).toBeUndefined()
   })
+
+  test('user ratings endpoint', async () => {
+    const user1 = { name: 'A', email: 'a@example.com', password: 'pass' }
+    await request(app).post('/api/register').send(user1)
+    const login1 = await request(app)
+      .post('/api/login')
+      .send({ email: user1.email, password: user1.password })
+    const token1 = login1.body.token
+    await request(app)
+      .post('/api/ratings')
+      .set('Authorization', `Bearer ${token1}`)
+      .send({ location: { name: 'Cafe1' }, ratings: {}, notes: '' })
+
+    const user2 = { name: 'B', email: 'b@example.com', password: 'pass' }
+    await request(app).post('/api/register').send(user2)
+    const login2 = await request(app)
+      .post('/api/login')
+      .send({ email: user2.email, password: user2.password })
+    const token2 = login2.body.token
+
+    const list1 = await request(app)
+      .get('/api/user/ratings')
+      .set('Authorization', `Bearer ${token1}`)
+    expect(list1.body.length).toBe(1)
+    expect(list1.body[0].userId).toBe(login1.body.user.id)
+
+    const list2 = await request(app)
+      .get('/api/user/ratings')
+      .set('Authorization', `Bearer ${token2}`)
+    expect(Array.isArray(list2.body)).toBe(true)
+    expect(list2.body.length).toBe(0)
+  })
 })

--- a/__tests__/server.test.js
+++ b/__tests__/server.test.js
@@ -2,13 +2,13 @@
 const request = require('supertest')
 const path = require('path')
 
-process.env.DATA_FILE = path.join(__dirname, 'test_data.json')
+process.env.DB_FILE = path.join(__dirname, 'test.db')
 const app = require('../server/index')
 const fs = require('fs')
 
 afterAll(() => {
-  if (fs.existsSync(process.env.DATA_FILE)) {
-    fs.unlinkSync(process.env.DATA_FILE)
+  if (fs.existsSync(process.env.DB_FILE)) {
+    fs.unlinkSync(process.env.DB_FILE)
   }
 })
 
@@ -27,7 +27,11 @@ describe('server api', () => {
       .send({ email: user.email, password: user.password })
     expect(res.status).toBe(200)
     expect(res.body.token).toBeDefined()
-    expect(res.body.user).toEqual({ id: expect.any(String), name: 'Test', email: user.email })
+    expect(res.body.user).toEqual({
+      id: expect.any(String),
+      name: 'Test',
+      email: user.email,
+    })
   })
 
   test('create and delete rating', async () => {

--- a/__tests__/server.test.js
+++ b/__tests__/server.test.js
@@ -22,6 +22,13 @@ describe('server api', () => {
   test('register and login', async () => {
     const user = { name: 'Test', email: 'test@example.com', password: 'pass' }
     await request(app).post('/api/register').send(user).expect(200)
+    const Database = require('better-sqlite3')
+    const db = new Database(process.env.DB_FILE)
+    const stored = db
+      .prepare('SELECT * FROM users WHERE email = ?')
+      .get(user.email)
+    db.close()
+    expect(stored).toBeDefined()
     const res = await request(app)
       .post('/api/login')
       .send({ email: user.email, password: user.password })

--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -3,6 +3,7 @@
 import type React from 'react'
 
 import { useState } from 'react'
+import { fetchUserRatings } from '../../../lib/api'
 import { useRouter } from 'next/navigation'
 import Link from 'next/link'
 import { Eye, EyeOff, ArrowRight, Mail, Lock } from 'lucide-react'
@@ -10,8 +11,7 @@ import Image from 'next/image'
 
 export default function LoginPage() {
   const router = useRouter()
-  const API_URL =
-    process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001'
+  const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001'
   const [formData, setFormData] = useState({
     email: '',
     password: '',
@@ -52,6 +52,16 @@ export default function LoginPage() {
           JSON.stringify({ email: formData.email }),
         )
       }
+
+      // refresh local ratings cache for this user
+      try {
+        const ratings = await fetchUserRatings(data.token)
+        localStorage.setItem('hotChocRatings', JSON.stringify(ratings))
+      } catch (err) {
+        console.error('Failed to fetch user ratings after login', err)
+        localStorage.removeItem('hotChocRatings')
+      }
+
       router.push('/dashboard')
     } catch (err: any) {
       console.error('Login failed', err)

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import Link from 'next/link'
 import Image from 'next/image'
-import { fetchRatings } from '../../lib/api'
+import { fetchUserRatings } from '../../lib/api'
 import {
   Star,
   MapPin,
@@ -68,10 +68,16 @@ export default function DashboardPage() {
     const userData = JSON.parse(currentUser)
     setUser(userData)
 
-    fetchRatings()
+    const token = localStorage.getItem('token')
+    if (!token) {
+      router.push('/auth/login')
+      return
+    }
+
+    fetchUserRatings(token)
       .then((all) => {
         localStorage.setItem('hotChocRatings', JSON.stringify(all))
-        const userRatings = all.filter((r: Rating) => r.userId === userData.id)
+        const userRatings = all
         setRatings(userRatings)
 
         let updatedUser

--- a/app/explore/page.tsx
+++ b/app/explore/page.tsx
@@ -12,6 +12,7 @@ import {
   CircleUserRound,
 } from 'lucide-react'
 import dynamic from 'next/dynamic'
+import { fetchRatings } from '../../lib/api'
 
 interface User {
   id: string
@@ -88,8 +89,9 @@ export default function ExplorePage() {
       setCurrentUser(JSON.parse(user))
     }
 
-    // In a real app this would fetch community data from the API
-    setCommunityRatings([])
+    fetchRatings()
+      .then((data) => setCommunityRatings(data))
+      .catch((err) => console.error('Failed to load ratings', err))
     setTopUsers([])
 
     // Load ratings saved locally

--- a/app/new/page.tsx
+++ b/app/new/page.tsx
@@ -240,7 +240,9 @@ export default function NewRatingPage() {
         try {
           const parsed = JSON.parse(stored)
           if (Array.isArray(parsed)) list = parsed
-        } catch {}
+        } catch {
+          // ignore parse errors for corrupted cache
+        }
       }
       localStorage.setItem('hotChocRatings', JSON.stringify([saved, ...list]))
     } catch (err: any) {

--- a/app/new/page.tsx
+++ b/app/new/page.tsx
@@ -5,6 +5,7 @@ import { useState, useRef, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { Camera, MapPin, Save, Sparkles, Zap, CheckCircle } from 'lucide-react'
 import NextImage from 'next/image'
+import { createRating } from '../../lib/api'
 
 interface RatingData {
   temperature: number
@@ -217,23 +218,13 @@ export default function NewRatingPage() {
     // Simulate API call delay for better UX
     await new Promise((resolve) => setTimeout(resolve, 1500))
 
-    const currentUserRaw = localStorage.getItem('currentUser')
-    let userId: string | undefined
-    if (currentUserRaw) {
-      try {
-        const parsed = JSON.parse(currentUserRaw)
-        if (parsed && typeof parsed.id === 'string') {
-          userId = parsed.id
-        }
-      } catch (err) {
-        console.error('Failed to parse current user info', err)
-        errorMessage = 'Failed to read user information.'
-      }
+    const token = localStorage.getItem('token')
+    if (!token) {
+      alert('Please login first')
+      setIsSaving(false)
+      return
     }
-
     const newRating = {
-      id: crypto.randomUUID(),
-      userId,
       photo,
       location,
       ratings,
@@ -241,36 +232,20 @@ export default function NewRatingPage() {
       timestamp: new Date().toISOString(),
     }
 
-    let existingRatings: any[] = []
     try {
+      const saved = await createRating(token, newRating)
       const stored = localStorage.getItem('hotChocRatings')
+      let list: any[] = []
       if (stored) {
-        existingRatings = JSON.parse(stored)
-        if (!Array.isArray(existingRatings)) {
-          existingRatings = []
-        }
+        try {
+          const parsed = JSON.parse(stored)
+          if (Array.isArray(parsed)) list = parsed
+        } catch {}
       }
-    } catch (err) {
-      console.error('Failed to read ratings from localStorage', err)
-      errorMessage = 'Failed to read saved ratings.'
-      existingRatings = []
-    }
-
-    const updatedRatings = [newRating, ...existingRatings]
-
-    try {
-      localStorage.setItem('hotChocRatings', JSON.stringify(updatedRatings))
+      localStorage.setItem('hotChocRatings', JSON.stringify([saved, ...list]))
     } catch (err: any) {
       console.error('Failed to save rating', err)
-      if (
-        err?.name === 'QuotaExceededError' ||
-        err?.name === 'NS_ERROR_DOM_QUOTA_REACHED'
-      ) {
-        errorMessage =
-          'Storage limit reached. Please remove old ratings or use smaller photos.'
-      } else {
-        errorMessage = 'Failed to save rating.'
-      }
+      errorMessage = err.message || 'Failed to save rating.'
     }
 
     setIsSaving(false)

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,9 +1,10 @@
-"use client"
+'use client'
 
-import { useState, useEffect } from "react"
-import { MapPin, Calendar, Star, Search, Sparkles } from "lucide-react"
-import Link from "next/link"
-import Image from "next/image"
+import { useState, useEffect } from 'react'
+import { MapPin, Calendar, Star, Search, Sparkles } from 'lucide-react'
+import Link from 'next/link'
+import Image from 'next/image'
+import { fetchRatings } from '../lib/api'
 
 interface Rating {
   id: string
@@ -28,29 +29,20 @@ interface Rating {
 export default function HomePage() {
   const [ratings, setRatings] = useState<Rating[]>([])
   const [isLoading, setIsLoading] = useState(true)
-  const [searchQuery, setSearchQuery] = useState("")
+  const [searchQuery, setSearchQuery] = useState('')
   const [showSearch, setShowSearch] = useState(false)
 
   useEffect(() => {
-    // Simulate loading for better UX
-    setTimeout(() => {
-      const savedRatings = localStorage.getItem("hotChocRatings")
-      if (savedRatings) {
-        try {
-          const parsed = JSON.parse(savedRatings)
-          if (Array.isArray(parsed)) {
-            setRatings(parsed)
-          } else {
-            console.error("Invalid ratings format in localStorage")
-            setRatings([])
-          }
-        } catch (err) {
-          console.error("Failed to parse saved ratings", err)
-          setRatings([])
-        }
-      }
-      setIsLoading(false)
-    }, 800)
+    fetchRatings()
+      .then((data) => {
+        setRatings(data)
+        localStorage.setItem('hotChocRatings', JSON.stringify(data))
+      })
+      .catch((err) => {
+        console.error('Failed to load ratings', err)
+        setRatings([])
+      })
+      .finally(() => setIsLoading(false))
   }, [])
 
   const formatDate = (timestamp: string) => {
@@ -59,20 +51,22 @@ export default function HomePage() {
     const diffTime = Math.abs(now.getTime() - date.getTime())
     const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24))
 
-    if (diffDays === 1) return "Today"
-    if (diffDays === 2) return "Yesterday"
+    if (diffDays === 1) return 'Today'
+    if (diffDays === 2) return 'Yesterday'
     if (diffDays <= 7) return `${diffDays - 1} days ago`
 
-    return date.toLocaleDateString("en-US", {
-      month: "short",
-      day: "numeric",
-      year: date.getFullYear() !== now.getFullYear() ? "numeric" : undefined,
+    return date.toLocaleDateString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      year: date.getFullYear() !== now.getFullYear() ? 'numeric' : undefined,
     })
   }
 
-  const getAverageRating = (ratingObj: Rating["ratings"]) => {
+  const getAverageRating = (ratingObj: Rating['ratings']) => {
     const values = Object.values(ratingObj)
-    return (values.reduce((sum, val) => sum + val, 0) / values.length).toFixed(1)
+    return (values.reduce((sum, val) => sum + val, 0) / values.length).toFixed(
+      1,
+    )
   }
 
   const filteredRatings = ratings.filter(
@@ -112,7 +106,9 @@ export default function HomePage() {
                 height={517}
                 className="h-24 w-auto mx-auto mb-2"
               />
-              <p className="text-amber-700/80">Discover & rate amazing hot chocolates</p>
+              <p className="text-amber-700/80">
+                Discover & rate amazing hot chocolates
+              </p>
             </div>
             <button
               onClick={() => setShowSearch(!showSearch)}
@@ -124,7 +120,7 @@ export default function HomePage() {
 
           {/* Search Bar */}
           <div
-            className={`transition-all duration-500 ease-out ${showSearch ? "max-h-20 opacity-100 mb-4" : "max-h-0 opacity-0"} overflow-hidden`}
+            className={`transition-all duration-500 ease-out ${showSearch ? 'max-h-20 opacity-100 mb-4' : 'max-h-0 opacity-0'} overflow-hidden`}
           >
             <div className="relative">
               <Search className="absolute left-4 top-1/2 transform -translate-y-1/2 w-5 h-5 text-amber-600" />
@@ -143,17 +139,22 @@ export default function HomePage() {
         {!isLoading && ratings.length > 0 && (
           <div className="grid grid-cols-2 gap-4 mb-6">
             <div className="bg-white/80 backdrop-blur-sm rounded-2xl p-4 text-center shadow-lg">
-              <div className="text-2xl font-bold text-amber-800">{ratings.length}</div>
+              <div className="text-2xl font-bold text-amber-800">
+                {ratings.length}
+              </div>
               <div className="text-sm text-amber-600">Total Ratings</div>
             </div>
             <div className="bg-white/80 backdrop-blur-sm rounded-2xl p-4 text-center shadow-lg">
               <div className="text-2xl font-bold text-amber-800">
                 {ratings.length > 0
                   ? (
-                      ratings.reduce((sum, r) => sum + Number.parseFloat(getAverageRating(r.ratings)), 0) /
-                      ratings.length
+                      ratings.reduce(
+                        (sum, r) =>
+                          sum + Number.parseFloat(getAverageRating(r.ratings)),
+                        0,
+                      ) / ratings.length
                     ).toFixed(1)
-                  : "0.0"}
+                  : '0.0'}
               </div>
               <div className="text-sm text-amber-600">Avg Rating</div>
             </div>
@@ -173,12 +174,12 @@ export default function HomePage() {
                 <Sparkles className="absolute top-2 right-8 w-6 h-6 text-amber-400 animate-pulse" />
               </div>
               <h3 className="text-xl font-semibold text-amber-900 mb-2">
-                {searchQuery ? "No matches found" : "No ratings yet"}
+                {searchQuery ? 'No matches found' : 'No ratings yet'}
               </h3>
               <p className="text-amber-700 mb-8 max-w-xs mx-auto">
                 {searchQuery
-                  ? "Try adjusting your search terms"
-                  : "Start your hot chocolate journey by rating your first cup!"}
+                  ? 'Try adjusting your search terms'
+                  : 'Start your hot chocolate journey by rating your first cup!'}
               </p>
               {!searchQuery && (
                 <Link href="/new">
@@ -196,12 +197,14 @@ export default function HomePage() {
                   className="group bg-white/80 backdrop-blur-sm rounded-2xl shadow-lg hover:shadow-xl p-4 flex gap-4 transition-all duration-300 hover:scale-[1.02] hover:bg-white/90 border border-white/20"
                   style={{
                     animationDelay: `${index * 100}ms`,
-                    animation: isLoading ? "none" : "slideInUp 0.6s ease-out forwards",
+                    animation: isLoading
+                      ? 'none'
+                      : 'slideInUp 0.6s ease-out forwards',
                   }}
                 >
                   <div className="relative w-16 h-16 rounded-xl overflow-hidden flex-shrink-0">
                     <Image
-                      src={rating.photo || "/placeholder.svg"}
+                      src={rating.photo || '/placeholder.svg'}
                       alt="Hot chocolate"
                       width={64}
                       height={64}
@@ -213,16 +216,23 @@ export default function HomePage() {
                     <div className="flex items-center gap-2 mb-2">
                       <div className="flex items-center gap-1">
                         <Star className="w-4 h-4 text-amber-500 fill-current" />
-                        <span className="font-bold text-amber-900 text-lg">{getAverageRating(rating.ratings)}</span>
+                        <span className="font-bold text-amber-900 text-lg">
+                          {getAverageRating(rating.ratings)}
+                        </span>
                       </div>
                       <div className="flex gap-1">
                         {Array.from({ length: 5 }).map((_, i) => (
                           <div
                             key={i}
                             className={`w-1.5 h-1.5 rounded-full transition-all duration-300 ${
-                              i < Math.round(Number.parseFloat(getAverageRating(rating.ratings)))
-                                ? "bg-amber-400"
-                                : "bg-amber-200"
+                              i <
+                              Math.round(
+                                Number.parseFloat(
+                                  getAverageRating(rating.ratings),
+                                ),
+                              )
+                                ? 'bg-amber-400'
+                                : 'bg-amber-200'
                             }`}
                           />
                         ))}
@@ -230,7 +240,9 @@ export default function HomePage() {
                     </div>
                     <div className="flex items-center gap-1 text-sm text-gray-600 mb-1">
                       <MapPin className="w-3 h-3 text-amber-500" />
-                      <span className="truncate font-medium">{rating.location.name}</span>
+                      <span className="truncate font-medium">
+                        {rating.location.name}
+                      </span>
                     </div>
                     <div className="flex items-center gap-1 text-sm text-gray-500 mb-2">
                       <Calendar className="w-3 h-3" />

--- a/app/view/[id]/page.tsx
+++ b/app/view/[id]/page.tsx
@@ -1,11 +1,12 @@
-"use client"
+'use client'
 
-import { useState, useEffect } from "react"
-import { useParams, useRouter } from "next/navigation"
-import { MapPin, Calendar, Star, Share2, Heart, Trash2 } from "lucide-react"
+import { useState, useEffect } from 'react'
+import { useParams, useRouter } from 'next/navigation'
+import { MapPin, Calendar, Star, Share2, Heart, Trash2 } from 'lucide-react'
 import { MapContainer, TileLayer, Marker, Popup } from 'react-leaflet'
-import Link from "next/link"
-import Image from "next/image"
+import Link from 'next/link'
+import Image from 'next/image'
+import { fetchRating, deleteRating } from '../../lib/api'
 
 interface Rating {
   id: string
@@ -36,25 +37,13 @@ export default function RatingDetailPage() {
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
 
   useEffect(() => {
-    setTimeout(() => {
-      let savedRatings: any[] = []
-      try {
-        const raw = localStorage.getItem("hotChocRatings")
-        if (raw) {
-          const parsed = JSON.parse(raw)
-          if (Array.isArray(parsed)) {
-            savedRatings = parsed
-          } else {
-            console.error("Invalid ratings format in localStorage")
-          }
-        }
-      } catch (err) {
-        console.error("Failed to parse saved ratings", err)
-      }
-      const foundRating = savedRatings.find((r: Rating) => r.id === params.id)
-      setRating(foundRating || null)
-      setIsLoading(false)
-    }, 500)
+    fetchRating(params.id as string)
+      .then((r) => setRating(r))
+      .catch((err) => {
+        console.error('Failed to load rating', err)
+        setRating(null)
+      })
+      .finally(() => setIsLoading(false))
   }, [params.id])
 
   if (isLoading) {
@@ -82,8 +71,12 @@ export default function RatingDetailPage() {
       <div className="min-h-screen bg-gradient-to-br from-amber-50 to-orange-100 flex items-center justify-center">
         <div className="text-center">
           <div className="text-8xl mb-6 opacity-30">☕</div>
-          <h2 className="text-2xl font-bold text-amber-900 mb-2">Rating not found</h2>
-          <p className="text-amber-700 mb-6">This rating might have been deleted or moved.</p>
+          <h2 className="text-2xl font-bold text-amber-900 mb-2">
+            Rating not found
+          </h2>
+          <p className="text-amber-700 mb-6">
+            This rating might have been deleted or moved.
+          </p>
           <Link
             href="/"
             className="bg-gradient-to-r from-amber-500 to-orange-500 text-white px-6 py-3 rounded-full font-semibold hover:shadow-lg transition-all duration-300 hover:scale-105"
@@ -96,33 +89,62 @@ export default function RatingDetailPage() {
   }
 
   const formatDate = (timestamp: string) => {
-    return new Date(timestamp).toLocaleDateString("en-US", {
-      weekday: "long",
-      year: "numeric",
-      month: "long",
-      day: "numeric",
-      hour: "2-digit",
-      minute: "2-digit",
+    return new Date(timestamp).toLocaleDateString('en-US', {
+      weekday: 'long',
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
     })
   }
 
-  const getAverageRating = (ratingObj: Rating["ratings"]) => {
+  const getAverageRating = (ratingObj: Rating['ratings']) => {
     const values = Object.values(ratingObj)
-    return (values.reduce((sum, val) => sum + val, 0) / values.length).toFixed(1)
+    return (values.reduce((sum, val) => sum + val, 0) / values.length).toFixed(
+      1,
+    )
   }
 
   const ratingLabels = {
-    temperature: { label: "Temperature", icon: "🌡️", color: "from-blue-400 to-red-400" },
-    sweetness: { label: "Sweetness", icon: "🍯", color: "from-gray-400 to-yellow-400" },
-    texture: { label: "Texture", icon: "🥛", color: "from-blue-300 to-amber-300" },
-    chocolate: { label: "Chocolate Intensity", icon: "🍫", color: "from-amber-400 to-amber-800" },
-    creaminess: { label: "Creaminess", icon: "🥛", color: "from-white to-amber-200" },
-    presentation: { label: "Presentation", icon: "✨", color: "from-gray-300 to-purple-400" },
+    temperature: {
+      label: 'Temperature',
+      icon: '🌡️',
+      color: 'from-blue-400 to-red-400',
+    },
+    sweetness: {
+      label: 'Sweetness',
+      icon: '🍯',
+      color: 'from-gray-400 to-yellow-400',
+    },
+    texture: {
+      label: 'Texture',
+      icon: '🥛',
+      color: 'from-blue-300 to-amber-300',
+    },
+    chocolate: {
+      label: 'Chocolate Intensity',
+      icon: '🍫',
+      color: 'from-amber-400 to-amber-800',
+    },
+    creaminess: {
+      label: 'Creaminess',
+      icon: '🥛',
+      color: 'from-white to-amber-200',
+    },
+    presentation: {
+      label: 'Presentation',
+      icon: '✨',
+      color: 'from-gray-300 to-purple-400',
+    },
   }
 
-  const handleDelete = () => {
+  const handleDelete = async () => {
     if (!rating) return
+    const token = localStorage.getItem('token')
+    if (!token) return
     try {
+      await deleteRating(token, rating.id)
       const raw = localStorage.getItem('hotChocRatings')
       if (raw) {
         const list = JSON.parse(raw)
@@ -140,202 +162,243 @@ export default function RatingDetailPage() {
 
   return (
     <>
-    <div className="min-h-screen bg-gradient-to-br from-amber-50 via-orange-50 to-rose-50">
-      {/* Animated Background */}
-      <div className="fixed inset-0 overflow-hidden pointer-events-none">
-        <div className="absolute -top-40 -right-40 w-80 h-80 bg-gradient-to-br from-amber-200/20 to-orange-300/20 rounded-full blur-3xl animate-pulse"></div>
-        <div className="absolute -bottom-40 -left-40 w-80 h-80 bg-gradient-to-br from-rose-200/20 to-pink-300/20 rounded-full blur-3xl animate-pulse delay-1000"></div>
-      </div>
-
-      <div className="relative max-w-md mx-auto px-4 py-6">
-        {/* Header */}
-        <div className="flex items-center justify-between mb-6">
-          <div className="text-center flex-1">
-            <h1 className="text-2xl font-bold bg-gradient-to-r from-amber-800 to-orange-700 bg-clip-text text-transparent">
-              Rating Details
-            </h1>
-          </div>
-
-          <div className="flex gap-2">
-            <button
-              onClick={() => setShowDeleteConfirm(true)}
-              className="p-3 bg-white/80 backdrop-blur-sm rounded-full shadow-lg hover:shadow-xl transition-all duration-300 hover:scale-105"
-            >
-              <Trash2 className="w-5 h-5 text-red-600" />
-            </button>
-            <button
-              onClick={() => setIsFavorite(!isFavorite)}
-              className="p-3 bg-white/80 backdrop-blur-sm rounded-full shadow-lg hover:shadow-xl transition-all duration-300 hover:scale-105"
-            >
-              <Heart
-                className={`w-5 h-5 transition-colors duration-300 ${isFavorite ? "text-red-500 fill-current" : "text-gray-400"}`}
-              />
-            </button>
-            <button className="p-3 bg-white/80 backdrop-blur-sm rounded-full shadow-lg hover:shadow-xl transition-all duration-300 hover:scale-105">
-              <Share2 className="w-5 h-5 text-amber-700" />
-            </button>
-          </div>
+      <div className="min-h-screen bg-gradient-to-br from-amber-50 via-orange-50 to-rose-50">
+        {/* Animated Background */}
+        <div className="fixed inset-0 overflow-hidden pointer-events-none">
+          <div className="absolute -top-40 -right-40 w-80 h-80 bg-gradient-to-br from-amber-200/20 to-orange-300/20 rounded-full blur-3xl animate-pulse"></div>
+          <div className="absolute -bottom-40 -left-40 w-80 h-80 bg-gradient-to-br from-rose-200/20 to-pink-300/20 rounded-full blur-3xl animate-pulse delay-1000"></div>
         </div>
 
-        <div className="space-y-6">
-          {/* Photo with Overlay Info */}
-          <div className="relative bg-white/80 backdrop-blur-sm rounded-3xl shadow-2xl overflow-hidden">
-            <Image
-              src={rating.photo || "/placeholder.svg"}
-              alt="Hot chocolate"
-              width={400}
-              height={400}
-              className="w-full aspect-square object-cover"
-            />
-            <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-transparent to-transparent"></div>
-            <div className="absolute bottom-6 left-6 right-6">
-              <div className="flex items-center justify-between">
-                <div className="flex items-center gap-3">
-                  <div className="flex items-center gap-2 bg-white/90 backdrop-blur-sm rounded-full px-4 py-2">
-                    <Star className="w-5 h-5 text-amber-500 fill-current" />
-                    <span className="text-2xl font-bold text-amber-900">{getAverageRating(rating.ratings)}</span>
-                  </div>
-                </div>
-                <div className="text-right">
-                  <p className="text-white font-semibold text-lg">{rating.location.name}</p>
-                  <p className="text-white/80 text-sm">{formatDate(rating.timestamp).split(",")[0]}</p>
-                </div>
-              </div>
+        <div className="relative max-w-md mx-auto px-4 py-6">
+          {/* Header */}
+          <div className="flex items-center justify-between mb-6">
+            <div className="text-center flex-1">
+              <h1 className="text-2xl font-bold bg-gradient-to-r from-amber-800 to-orange-700 bg-clip-text text-transparent">
+                Rating Details
+              </h1>
+            </div>
+
+            <div className="flex gap-2">
+              <button
+                onClick={() => setShowDeleteConfirm(true)}
+                className="p-3 bg-white/80 backdrop-blur-sm rounded-full shadow-lg hover:shadow-xl transition-all duration-300 hover:scale-105"
+              >
+                <Trash2 className="w-5 h-5 text-red-600" />
+              </button>
+              <button
+                onClick={() => setIsFavorite(!isFavorite)}
+                className="p-3 bg-white/80 backdrop-blur-sm rounded-full shadow-lg hover:shadow-xl transition-all duration-300 hover:scale-105"
+              >
+                <Heart
+                  className={`w-5 h-5 transition-colors duration-300 ${isFavorite ? 'text-red-500 fill-current' : 'text-gray-400'}`}
+                />
+              </button>
+              <button className="p-3 bg-white/80 backdrop-blur-sm rounded-full shadow-lg hover:shadow-xl transition-all duration-300 hover:scale-105">
+                <Share2 className="w-5 h-5 text-amber-700" />
+              </button>
             </div>
           </div>
 
-          {/* Quick Stats */}
-          <div className="grid grid-cols-3 gap-4">
-            <div className="bg-white/80 backdrop-blur-sm rounded-2xl p-4 text-center shadow-lg">
-              <div className="text-2xl font-bold text-amber-800">{getAverageRating(rating.ratings)}</div>
-              <div className="text-sm text-amber-600">Overall</div>
-            </div>
-            <div className="bg-white/80 backdrop-blur-sm rounded-2xl p-4 text-center shadow-lg">
-              <div className="text-2xl font-bold text-amber-800">{Math.max(...Object.values(rating.ratings))}</div>
-              <div className="text-sm text-amber-600">Highest</div>
-            </div>
-            <div className="bg-white/80 backdrop-blur-sm rounded-2xl p-4 text-center shadow-lg">
-              <div className="text-2xl font-bold text-amber-800">
-                {Object.values(rating.ratings).filter((r) => r >= 4).length}
-              </div>
-              <div className="text-sm text-amber-600">4+ Stars</div>
-            </div>
-          </div>
-
-          {/* Location & Date Details */}
-          <div className="bg-white/80 backdrop-blur-sm rounded-2xl shadow-lg p-6">
-            <div className="space-y-4">
-              <div className="flex items-start gap-4">
-                <div className="p-3 bg-gradient-to-r from-blue-400 to-cyan-400 rounded-full">
-                  <MapPin className="w-5 h-5 text-white" />
-                </div>
-                <div className="flex-1">
-                  <h3 className="font-semibold text-amber-900 mb-1">Location</h3>
-                  <p className="text-gray-700">{rating.location.name}</p>
-                  {rating.location.lat !== 0 && rating.location.lng !== 0 && (
-                    <p className="text-sm text-gray-500 mt-1">
-                      {rating.location.lat.toFixed(4)}, {rating.location.lng.toFixed(4)}
-                    </p>
-                  )}
-                  {rating.location.lat !== 0 && rating.location.lng !== 0 && (
-                    <div className="h-48 mt-4 rounded-xl overflow-hidden">
-                      <MapContainer
-                        center={[rating.location.lat, rating.location.lng]}
-                        zoom={16}
-                        style={{ height: '100%', width: '100%' }}
-                        scrollWheelZoom={false}
-                      >
-                        <TileLayer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" />
-                        <Marker position={[rating.location.lat, rating.location.lng]}>
-                          <Popup>{rating.location.name}</Popup>
-                        </Marker>
-                      </MapContainer>
-                    </div>
-                  )}
-                </div>
-              </div>
-
-              <div className="flex items-start gap-4">
-                <div className="p-3 bg-gradient-to-r from-purple-400 to-pink-400 rounded-full">
-                  <Calendar className="w-5 h-5 text-white" />
-                </div>
-                <div className="flex-1">
-                  <h3 className="font-semibold text-amber-900 mb-1">Date & Time</h3>
-                  <p className="text-gray-700">{formatDate(rating.timestamp)}</p>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          {/* Detailed Ratings with Animations */}
-          <div className="bg-white/80 backdrop-blur-sm rounded-2xl shadow-lg p-6">
-            <h2 className="text-xl font-bold text-amber-900 mb-6 flex items-center gap-2">
-              <Star className="w-6 h-6 text-amber-500" />
-              Detailed Ratings
-            </h2>
-            <div className="space-y-6">
-              {Object.entries(rating.ratings).map(([key, value], index) => (
-                <div key={key} className="group">
-                  <div className="flex items-center justify-between mb-3">
-                    <div className="flex items-center gap-3">
-                      <span className="text-2xl">{ratingLabels[key as keyof typeof ratingLabels].icon}</span>
-                      <span className="font-semibold text-amber-900">
-                        {ratingLabels[key as keyof typeof ratingLabels].label}
+          <div className="space-y-6">
+            {/* Photo with Overlay Info */}
+            <div className="relative bg-white/80 backdrop-blur-sm rounded-3xl shadow-2xl overflow-hidden">
+              <Image
+                src={rating.photo || '/placeholder.svg'}
+                alt="Hot chocolate"
+                width={400}
+                height={400}
+                className="w-full aspect-square object-cover"
+              />
+              <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-transparent to-transparent"></div>
+              <div className="absolute bottom-6 left-6 right-6">
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-3">
+                    <div className="flex items-center gap-2 bg-white/90 backdrop-blur-sm rounded-full px-4 py-2">
+                      <Star className="w-5 h-5 text-amber-500 fill-current" />
+                      <span className="text-2xl font-bold text-amber-900">
+                        {getAverageRating(rating.ratings)}
                       </span>
                     </div>
-                    <div className="flex items-center gap-2">
-                      <span className="text-xl font-bold text-amber-600">{value}</span>
-                      <div className="flex gap-1">
-                        {Array.from({ length: 5 }).map((_, i) => (
-                          <Star
-                            key={i}
-                            className={`w-4 h-4 transition-all duration-300 ${
-                              i < value ? "text-amber-400 fill-current scale-110" : "text-amber-200"
-                            }`}
-                          />
-                        ))}
-                      </div>
-                    </div>
                   </div>
-
-                  <div className="relative h-3 bg-gradient-to-r from-amber-100 to-orange-100 rounded-full overflow-hidden">
-                    <div
-                      className={`h-full bg-gradient-to-r ${ratingLabels[key as keyof typeof ratingLabels].color} rounded-full transition-all duration-1000 ease-out`}
-                      style={{
-                        width: `${(value / 5) * 100}%`,
-                        animationDelay: `${index * 200}ms`,
-                      }}
-                    />
+                  <div className="text-right">
+                    <p className="text-white font-semibold text-lg">
+                      {rating.location.name}
+                    </p>
+                    <p className="text-white/80 text-sm">
+                      {formatDate(rating.timestamp).split(',')[0]}
+                    </p>
                   </div>
                 </div>
-              ))}
-            </div>
-          </div>
-
-          {/* Notes */}
-          {rating.notes && (
-            <div className="bg-white/80 backdrop-blur-sm rounded-2xl shadow-lg p-6">
-              <h2 className="text-xl font-bold text-amber-900 mb-4 flex items-center gap-2">📝 Tasting Notes</h2>
-              <div className="bg-gradient-to-r from-amber-50 to-orange-50 rounded-xl p-4 border-l-4 border-amber-400">
-                <p className="text-gray-700 leading-relaxed italic">"{rating.notes}"</p>
               </div>
             </div>
-          )}
 
-        </div>
-      </div>
-    </div>
-    {showDeleteConfirm && (
-      <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
-        <div className="bg-white/90 backdrop-blur-md rounded-2xl shadow-2xl p-6 w-full max-w-sm text-center space-y-4">
-          <p className="text-amber-900 font-semibold">Delete this rating?</p>
-          <div className="flex gap-3">
-            <button onClick={() => setShowDeleteConfirm(false)} className="flex-1 bg-gray-200 hover:bg-gray-300 text-gray-700 py-2 px-4 rounded-xl transition-colors">Cancel</button>
-            <button onClick={handleDelete} className="flex-1 bg-red-500 hover:bg-red-600 text-white py-2 px-4 rounded-xl transition-colors">Delete</button>
+            {/* Quick Stats */}
+            <div className="grid grid-cols-3 gap-4">
+              <div className="bg-white/80 backdrop-blur-sm rounded-2xl p-4 text-center shadow-lg">
+                <div className="text-2xl font-bold text-amber-800">
+                  {getAverageRating(rating.ratings)}
+                </div>
+                <div className="text-sm text-amber-600">Overall</div>
+              </div>
+              <div className="bg-white/80 backdrop-blur-sm rounded-2xl p-4 text-center shadow-lg">
+                <div className="text-2xl font-bold text-amber-800">
+                  {Math.max(...Object.values(rating.ratings))}
+                </div>
+                <div className="text-sm text-amber-600">Highest</div>
+              </div>
+              <div className="bg-white/80 backdrop-blur-sm rounded-2xl p-4 text-center shadow-lg">
+                <div className="text-2xl font-bold text-amber-800">
+                  {Object.values(rating.ratings).filter((r) => r >= 4).length}
+                </div>
+                <div className="text-sm text-amber-600">4+ Stars</div>
+              </div>
+            </div>
+
+            {/* Location & Date Details */}
+            <div className="bg-white/80 backdrop-blur-sm rounded-2xl shadow-lg p-6">
+              <div className="space-y-4">
+                <div className="flex items-start gap-4">
+                  <div className="p-3 bg-gradient-to-r from-blue-400 to-cyan-400 rounded-full">
+                    <MapPin className="w-5 h-5 text-white" />
+                  </div>
+                  <div className="flex-1">
+                    <h3 className="font-semibold text-amber-900 mb-1">
+                      Location
+                    </h3>
+                    <p className="text-gray-700">{rating.location.name}</p>
+                    {rating.location.lat !== 0 && rating.location.lng !== 0 && (
+                      <p className="text-sm text-gray-500 mt-1">
+                        {rating.location.lat.toFixed(4)},{' '}
+                        {rating.location.lng.toFixed(4)}
+                      </p>
+                    )}
+                    {rating.location.lat !== 0 && rating.location.lng !== 0 && (
+                      <div className="h-48 mt-4 rounded-xl overflow-hidden">
+                        <MapContainer
+                          center={[rating.location.lat, rating.location.lng]}
+                          zoom={16}
+                          style={{ height: '100%', width: '100%' }}
+                          scrollWheelZoom={false}
+                        >
+                          <TileLayer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" />
+                          <Marker
+                            position={[
+                              rating.location.lat,
+                              rating.location.lng,
+                            ]}
+                          >
+                            <Popup>{rating.location.name}</Popup>
+                          </Marker>
+                        </MapContainer>
+                      </div>
+                    )}
+                  </div>
+                </div>
+
+                <div className="flex items-start gap-4">
+                  <div className="p-3 bg-gradient-to-r from-purple-400 to-pink-400 rounded-full">
+                    <Calendar className="w-5 h-5 text-white" />
+                  </div>
+                  <div className="flex-1">
+                    <h3 className="font-semibold text-amber-900 mb-1">
+                      Date & Time
+                    </h3>
+                    <p className="text-gray-700">
+                      {formatDate(rating.timestamp)}
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            {/* Detailed Ratings with Animations */}
+            <div className="bg-white/80 backdrop-blur-sm rounded-2xl shadow-lg p-6">
+              <h2 className="text-xl font-bold text-amber-900 mb-6 flex items-center gap-2">
+                <Star className="w-6 h-6 text-amber-500" />
+                Detailed Ratings
+              </h2>
+              <div className="space-y-6">
+                {Object.entries(rating.ratings).map(([key, value], index) => (
+                  <div key={key} className="group">
+                    <div className="flex items-center justify-between mb-3">
+                      <div className="flex items-center gap-3">
+                        <span className="text-2xl">
+                          {ratingLabels[key as keyof typeof ratingLabels].icon}
+                        </span>
+                        <span className="font-semibold text-amber-900">
+                          {ratingLabels[key as keyof typeof ratingLabels].label}
+                        </span>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <span className="text-xl font-bold text-amber-600">
+                          {value}
+                        </span>
+                        <div className="flex gap-1">
+                          {Array.from({ length: 5 }).map((_, i) => (
+                            <Star
+                              key={i}
+                              className={`w-4 h-4 transition-all duration-300 ${
+                                i < value
+                                  ? 'text-amber-400 fill-current scale-110'
+                                  : 'text-amber-200'
+                              }`}
+                            />
+                          ))}
+                        </div>
+                      </div>
+                    </div>
+
+                    <div className="relative h-3 bg-gradient-to-r from-amber-100 to-orange-100 rounded-full overflow-hidden">
+                      <div
+                        className={`h-full bg-gradient-to-r ${ratingLabels[key as keyof typeof ratingLabels].color} rounded-full transition-all duration-1000 ease-out`}
+                        style={{
+                          width: `${(value / 5) * 100}%`,
+                          animationDelay: `${index * 200}ms`,
+                        }}
+                      />
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            {/* Notes */}
+            {rating.notes && (
+              <div className="bg-white/80 backdrop-blur-sm rounded-2xl shadow-lg p-6">
+                <h2 className="text-xl font-bold text-amber-900 mb-4 flex items-center gap-2">
+                  📝 Tasting Notes
+                </h2>
+                <div className="bg-gradient-to-r from-amber-50 to-orange-50 rounded-xl p-4 border-l-4 border-amber-400">
+                  <p className="text-gray-700 leading-relaxed italic">
+                    "{rating.notes}"
+                  </p>
+                </div>
+              </div>
+            )}
           </div>
         </div>
       </div>
-    )}
+      {showDeleteConfirm && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
+          <div className="bg-white/90 backdrop-blur-md rounded-2xl shadow-2xl p-6 w-full max-w-sm text-center space-y-4">
+            <p className="text-amber-900 font-semibold">Delete this rating?</p>
+            <div className="flex gap-3">
+              <button
+                onClick={() => setShowDeleteConfirm(false)}
+                className="flex-1 bg-gray-200 hover:bg-gray-300 text-gray-700 py-2 px-4 rounded-xl transition-colors"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleDelete}
+                className="flex-1 bg-red-500 hover:bg-red-600 text-white py-2 px-4 rounded-xl transition-colors"
+              >
+                Delete
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </>
   )
 }

--- a/app/view/[id]/page.tsx
+++ b/app/view/[id]/page.tsx
@@ -6,7 +6,7 @@ import { MapPin, Calendar, Star, Share2, Heart, Trash2 } from 'lucide-react'
 import { MapContainer, TileLayer, Marker, Popup } from 'react-leaflet'
 import Link from 'next/link'
 import Image from 'next/image'
-import { fetchRating, deleteRating } from '../../lib/api'
+import { fetchRating, deleteRating } from '../../../lib/api'
 
 interface Rating {
   id: string

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,0 +1,34 @@
+const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001'
+
+export async function fetchRatings() {
+  const res = await fetch(`${API_URL}/api/ratings`)
+  if (!res.ok) throw new Error('Failed to fetch ratings')
+  return res.json()
+}
+
+export async function fetchRating(id: string) {
+  const res = await fetch(`${API_URL}/api/ratings/${id}`)
+  if (!res.ok) throw new Error('Failed to fetch rating')
+  return res.json()
+}
+
+export async function createRating(token: string, rating: any) {
+  const res = await fetch(`${API_URL}/api/ratings`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify(rating),
+  })
+  if (!res.ok) throw new Error('Failed to save rating')
+  return res.json()
+}
+
+export async function deleteRating(token: string, id: string) {
+  const res = await fetch(`${API_URL}/api/ratings/${id}`, {
+    method: 'DELETE',
+    headers: { Authorization: `Bearer ${token}` },
+  })
+  if (!res.ok) throw new Error('Failed to delete rating')
+}

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -6,6 +6,14 @@ export async function fetchRatings() {
   return res.json()
 }
 
+export async function fetchUserRatings(token: string) {
+  const res = await fetch(`${API_URL}/api/user/ratings`, {
+    headers: { Authorization: `Bearer ${token}` },
+  })
+  if (!res.ok) throw new Error('Failed to fetch user ratings')
+  return res.json()
+}
+
 export async function fetchRating(id: string) {
   const res = await fetch(`${API_URL}/api/ratings/${id}`)
   if (!res.ok) throw new Error('Failed to fetch rating')

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "bcryptjs": "^3.0.2",
+    "better-sqlite3": "^12.2.0",
     "body-parser": "^2.2.0",
     "class-variance-authority": "^0.7.0",
     "cors": "^2.8.5",

--- a/server/index.js
+++ b/server/index.js
@@ -81,6 +81,13 @@ app.get('/api/ratings', (req, res) => {
   res.json(rows.map((r) => JSON.parse(r.data)))
 })
 
+app.get('/api/user/ratings', authMiddleware, (req, res) => {
+  const rows = db
+    .prepare('SELECT data FROM ratings WHERE userId = ?')
+    .all(req.user.id)
+  res.json(rows.map((r) => JSON.parse(r.data)))
+})
+
 app.post('/api/ratings', authMiddleware, (req, res) => {
   const rating = { id: Date.now().toString(), userId: req.user.id, ...req.body }
   db.prepare('INSERT INTO ratings (id,userId,data) VALUES (?,?,?)').run(

--- a/server/index.js
+++ b/server/index.js
@@ -89,7 +89,7 @@ app.get('/api/user/ratings', authMiddleware, (req, res) => {
 })
 
 app.post('/api/ratings', authMiddleware, (req, res) => {
-  const rating = { id: Date.now().toString(), userId: req.user.id, ...req.body }
+  const rating = { id: Date.now().toString(), ...req.body, userId: req.user.id }
   db.prepare('INSERT INTO ratings (id,userId,data) VALUES (?,?,?)').run(
     rating.id,
     rating.userId,

--- a/server/index.js
+++ b/server/index.js
@@ -32,7 +32,7 @@ db.prepare(
 
 const app = express()
 app.use(cors())
-app.use(bodyParser.json())
+app.use(bodyParser.json({ limit: '10mb' }))
 app.use(morgan('combined'))
 
 function authMiddleware(req, res, next) {

--- a/server/package.json
+++ b/server/package.json
@@ -17,6 +17,7 @@
     "cors": "^2.8.5",
     "express": "^5.1.0",
     "jsonwebtoken": "^9.0.2",
-    "morgan": "^1.10.0"
+    "morgan": "^1.10.0",
+    "better-sqlite3": "^12.2.0"
   }
 }


### PR DESCRIPTION
## Summary
- persist backend data to a SQLite database
- add small API helper library
- fetch and store ratings through the API
- update tests for new DB environment
- document database usage

## Testing
- `npx prettier --write "**/*.{ts,tsx,js,json,md}"`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686c5af1d4fc832a9c8a9063fd58839c